### PR TITLE
Ignore cabal.sandbox.config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+cabal.sandbox.config
 .hsenv
 dist
 *.o


### PR DESCRIPTION
`cabal.sandbox. config` should be ignored since will be local to the environment.
