### PR TITLE
Update dependencies

### DIFF
--- a/app.cabal
+++ b/app.cabal
@@ -19,10 +19,8 @@ executable app
   main-is:             Main.hs
   -- other-modules:       
   other-extensions:    OverloadedStrings
-  build-depends:       base ==4.5.*, 
-                       wai ==1.3.*,
-                       warp ==1.3.*,
-                       wai-extra >=1.3 && <1.4, 
+  build-depends:       base >=4.3.1, 
+                       wai-extra >=3.0.0,
                        wai-middleware-static,
                        scotty,
                        clay, 


### PR DESCRIPTION
Remove dependencies which aren't directly required and update versions
for existing ones. With the existing `build-depends`,  the `cabal build` fails. This change makes the dependencies more relaxed.